### PR TITLE
Loosen http dependency version

### DIFF
--- a/lib/namira/version.rb
+++ b/lib/namira/version.rb
@@ -1,3 +1,3 @@
 module Namira
-  VERSION = '0.1.4'.freeze
+  VERSION = '0.2.0'.freeze
 end

--- a/namira.gemspec
+++ b/namira.gemspec
@@ -27,9 +27,9 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_development_dependency 'bundler', '~> 1.11'
+  spec.add_development_dependency 'bundler', '~> 1.15'
   spec.add_development_dependency 'rake',    '~> 10.0'
   spec.add_development_dependency 'rspec',   '~> 3.0'
   spec.add_development_dependency 'pry'
-  spec.add_dependency 'http', '>= 2.0.0', '< 2.1'
+  spec.add_dependency 'http', '>= 2.0.0', '< 4.0'
 end


### PR DESCRIPTION
3.0 is current and it basically just dropped support for Ruby 2.0 and 2.1.

https://github.com/httprb/http/blob/master/CHANGES.md