### PR TITLE
fix: prevent bugsnag invalid api key warnings

### DIFF
--- a/lib/namira/error_helpers.rb
+++ b/lib/namira/error_helpers.rb
@@ -31,7 +31,7 @@ if defined?(::Bugsnag)
     end
   end
 
-  ::Bugsnag.configure do |config|
+  ::Bugsnag.configure(false) do |config|
     config.middleware.use Namira::ErrorHelpers::Bugsnag
   end
 end


### PR DESCRIPTION
This was released in [Bugsnag v6.7.1 on April 11, 2018](https://github.com/bugsnag/bugsnag-ruby/releases/tag/v6.7.1). Perhaps that's old enough to not need the version checking here?